### PR TITLE
Allow description key when validating responses

### DIFF
--- a/test/route_swagger/core_test.clj
+++ b/test/route_swagger/core_test.clj
@@ -66,7 +66,8 @@
   (sw.doc/annotate
     {:summary    "Get all resources"
      :parameters {:query-params {:q s/Str}}
-     :responses  {200      {:body {:status s/Str}}
+     :responses  {200      {:schema {:status s/Str}
+                            :description "The available resources."}
                   :default {:body    {:result [s/Str]}
                             :headers {(req "Location") s/Str}}}}
     (i/interceptor
@@ -119,7 +120,8 @@
                  :summary     "Get all resources"
                  :parameters  {:query  {:q s/Str}
                                :header {(req "auth") s/Str}}
-                 :responses   {200      {:schema {:status s/Str}}
+                 :responses   {200      {:schema {:status s/Str}
+                                         :description "The available resources."}
                                :default {:schema  {:result [s/Str]}
                                          :headers {(req "Location") s/Str}}}
                  :operationId "get-handler"}}


### PR DESCRIPTION
OpenAPI 2 provides a [response object *description* field](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responseObject) which is useful to describe informally the semantic associated with the
response schema.

This field is currently not supported by the`validate-response` interceptor. The PR fixes that limitation and adapt existing test suite to check that this is properly handled.

[frankiesardo/route-swagger](https://github.com/frankiesardo/route-swagger) seems unmaintained so I am submitting the PR to your fork which seems more actively maintained for the purpose of supporting [pedestal-api](https://github.com/oliyh/pedestal-api)